### PR TITLE
Feature/change match list to table

### DIFF
--- a/src/app/components/division-match-list/division-match-list.component.ts
+++ b/src/app/components/division-match-list/division-match-list.component.ts
@@ -33,7 +33,7 @@ export class DivisionMatchListComponent implements OnInit {
           this.teamService.getTeamsByDivision(division.id)
             .subscribe(teams => this.teams = teams)
 
-          this.matchService.getMatchesBySeason(division.seasons[0].id)
+          this.matchService.getMatchesBySeason(division.seasons[division.seasons.length-1].id)
             .subscribe(matches => this.matches = matches)
         })
     })

--- a/src/app/components/division-table/division-table.component.ts
+++ b/src/app/components/division-table/division-table.component.ts
@@ -73,7 +73,7 @@ export class DivisionTableComponent implements OnInit {
 
             // If we have a query parameter for season we use it
             let season = route.queryParams.season == null ?
-              division.seasons[0].id : division.seasons.find(
+              division.seasons[this.seasons.length-1].id : division.seasons.find(
                 season => season.key === route.queryParams.season).id
 
             this.seasonChanged(season)

--- a/src/app/components/match-list/match-list.component.html
+++ b/src/app/components/match-list/match-list.component.html
@@ -1,3 +1,28 @@
+<table mat-table [dataSource]="setupDataSource()"  multiTemplateDataRows class="mat-elevation-z8">
+
+  <ng-container matColumnDef="date">
+    <th mat-header-cell *matHeaderCellDef>Date</th>
+    <td mat-cell *matCellDef="let element"> {{element.date}} </td>
+  </ng-container>
+  <ng-container matColumnDef="homeTeam">
+    <th mat-header-cell *matHeaderCellDef>Home team</th>
+    <td mat-cell *matCellDef="let element"> {{element.homeTeam}} </td>
+  </ng-container>
+  <ng-container matColumnDef="awayTeam">
+    <th mat-header-cell *matHeaderCellDef>Away team</th>
+    <td mat-cell *matCellDef="let element"> {{element.awayTeam}} </td>
+  </ng-container>
+  <ng-container matColumnDef="score">
+    <th mat-header-cell *matHeaderCellDef>Score</th>
+    <td mat-cell *matCellDef="let element"> {{element.score}} </td>
+  </ng-container>
+  
+
+<tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+<tr mat-row *matRowDef="let element; columns: columnsToDisplay"></tr>
+
+
+</table>
 <mat-list>
   <h3 mat-subheader>Matches</h3>
   <mat-list-item *ngFor="let match of matches">

--- a/src/app/components/match-list/match-list.component.html
+++ b/src/app/components/match-list/match-list.component.html
@@ -8,6 +8,9 @@
         {{ set.homeScore }} - {{ set.awayScore }}
       </span>
     </p>
+    <p mat-line>
+      Referee: {{ this.showReferee(match.referee, teams) }}
+    </p>
     <mat-divider></mat-divider>
   </mat-list-item>
 </mat-list>

--- a/src/app/components/match-list/match-list.component.scss
+++ b/src/app/components/match-list/match-list.component.scss
@@ -1,0 +1,32 @@
+table {
+    width: 100%;
+  }
+  
+  tr.example-detail-row {
+    height: 0;
+  }
+  
+  tr.example-element-row:not(.example-expanded-row):hover {
+    background: whitesmoke;
+  }
+  
+  tr.example-element-row:not(.example-expanded-row):active {
+    background: #efefef;
+  }
+  
+  .example-element-row td {
+    border-bottom-width: 0;
+  }
+  
+  .example-element-detail {
+    overflow: hidden;
+    display: flex;
+  }
+  
+  .example-element-description {
+    padding: 16px;
+  }
+  
+  .example-element-description-attribution {
+    opacity: 0.5;
+  }

--- a/src/app/components/match-list/match-list.component.ts
+++ b/src/app/components/match-list/match-list.component.ts
@@ -1,18 +1,42 @@
 import { Component, OnInit, Input } from '@angular/core'
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import { MatSort, MatTableDataSource } from '@angular/material'
+import { AuthenticationService } from '@services/authentication.service';
 import { Match } from '@models/match'
 import { Team } from '@models/team'
+import { Set } from '@models/set'
+
+interface MatchResult {
+  date: string,
+  homeTeam: string,
+  awayTeam: string,
+  score: string,
+}
 
 @Component({
   selector: 'app-match-list',
   templateUrl: './match-list.component.html',
-  styleUrls: ['./match-list.component.scss']
+  styleUrls: ['./match-list.component.scss'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
 export class MatchListComponent implements OnInit {
 
   @Input() matches: Match[]
   @Input() teams: Team[]
 
-  constructor() { }
+  columnsToDisplay = ['date', 'homeTeam', 'awayTeam', 'score'];
+  dataSource: MatTableDataSource<MatchResult>;
+  expandedElement: MatchResult | null;
+
+  constructor(
+    private authService: AuthenticationService,
+  ) { }
 
   ngOnInit() { }
 
@@ -22,5 +46,31 @@ export class MatchListComponent implements OnInit {
 
   showReferee(id: number, teams:Team[]): string {
     return id ? this.getTeamNameById(id, teams) : "No referee set"
+  }
+
+  getConcatinatedSets(sets: Set[]): string {
+    var homeWin: number = 0;
+    var awayWin: number = 0;
+    sets.forEach(
+      set => {
+      set.homeScore > set.awayScore ? homeWin++ : awayWin++
+    });
+    return homeWin + " - " + awayWin
+  }
+
+  setupDataSource(): MatTableDataSource<MatchResult> {
+    let dataSource: MatTableDataSource<MatchResult> = new MatTableDataSource(
+      this.matches.map(match => {
+        let combSets: string = this.getConcatinatedSets(match.sets);
+        return {
+          date: 'Not here yet',
+          homeTeam: this.getTeamNameById(match.homeTeam, this.teams),
+          awayTeam:
+            this.getTeamNameById(match.awayTeam, this.teams),
+          score: combSets,
+        }
+      }))
+
+      return dataSource;
   }
 }

--- a/src/app/components/match-list/match-list.component.ts
+++ b/src/app/components/match-list/match-list.component.ts
@@ -19,4 +19,8 @@ export class MatchListComponent implements OnInit {
   getTeamNameById(id: number, teams: Team[]): string {
     return teams.find(team => team.id == id).name
   }
+
+  showReferee(id: number, teams:Team[]): string {
+    return id ? this.getTeamNameById(id, teams) : "No referee set"
+  }
 }

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -16,6 +16,8 @@
       routerLink="/divisions/{{division.key}}">{{division.name}}</a>
   </mat-menu>
 
+  <span class="right-align-spacer"></span>
+  
   <a mat-button *ngIf="!this.authService.isAuthenticated()"
     routerLink="/login">Login</a>
   <a mat-button *ngIf="!this.authService.isAuthenticated()"

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -1,0 +1,3 @@
+.right-align-spacer {
+    flex: 1 1 auto;
+  }

--- a/src/app/models/match.ts
+++ b/src/app/models/match.ts
@@ -5,6 +5,7 @@ export interface MatchRes {
   home_team: number
   away_team: number
   sets: SetRes[]
+  referee: number
 }
 
 export class Match {
@@ -12,11 +13,13 @@ export class Match {
   homeTeam: number
   awayTeam: number
   sets: Set[]
+  referee: number
 
   constructor(res: MatchRes) {
     this.id = res.id
     this.homeTeam = res.home_team
     this.awayTeam = res.away_team
     this.sets = res.sets ? res.sets.map(set => new Set(set)) : null
+    this.referee = res.referee
   }
 }


### PR DESCRIPTION
This is a work in progress, but I want you to have a look at it since you are reluctant to use table here instead of list. For now I have just added the table in the beginning of the page, but my idea is later to remove the list completely.

I would also like to make each row expandable by clicking, and that when doing so you will get more information about the exact score of each set, referee and so on. Maybe also be able to add score/change referee from this view. Let me know what you think!